### PR TITLE
Make scenario weight a keyword arg in examples for clarity

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -56,7 +56,7 @@ and create our first real load test::
 
     from molotov import scenario
 
-    @scenario(100)
+    @scenario(weight=100)
     async def _test(session):
         async with session.get('https://example.com') as resp:
             assert resp.status == 200, resp.status
@@ -130,16 +130,16 @@ You can add more scenarii and adapt their weights::
 
     from molotov import scenario
 
-    @scenario(20)
+    @scenario(weight=20)
     async def _test(session):
         async with session.get('https://example.com') as resp:
             assert resp.status == 200, resp.status
 
-    @scenario(20)
+    @scenario(weight=20)
     async def _test2(session):
         # do something
 
-    @scenario(60)
+    @scenario(weight=60)
     async def _test3(session):
         # do something different
 

--- a/molotov/quickstart/loadtest.py
+++ b/molotov/quickstart/loadtest.py
@@ -50,7 +50,7 @@ def test_ends():
 
 # each scenario has a weight. Molotov uses it to determine
 # how often the scenario is picked.
-@scenario(40)
+@scenario(weight=40)
 async def scenario_one(session):
     async with session.get(_API) as resp:
         # if Molotov is called with --statsd
@@ -65,7 +65,7 @@ async def scenario_one(session):
 
 
 # all scenarii are coroutines
-@scenario(30)
+@scenario(weight=30)
 async def scenario_two(session):
     # a call to one of the session method should be awaited
     # see aiohttp.Client docs for more info on this
@@ -73,7 +73,7 @@ async def scenario_two(session):
         assert resp.status == 200
 
 
-@scenario(30)
+@scenario(weight=30)
 async def scenario_three(session):
     somedata = json.dumps({'OK': 1})
     async with session.post(_API, data=somedata) as resp:

--- a/molotov/tests/example.py
+++ b/molotov/tests/example.py
@@ -30,7 +30,7 @@ def end_worker(worker_num):
     print("This is the end for %d" % worker_num)
 
 
-@scenario(40)
+@scenario(weight=40)
 async def scenario_one(session):
     async with session.get(_API) as resp:
         if session.statsd:
@@ -40,13 +40,13 @@ async def scenario_one(session):
         assert resp.status == 200
 
 
-@scenario(30)
+@scenario(weight=30)
 async def scenario_two(session):
     async with session.get(_API) as resp:
         assert resp.status == 200
 
 
-@scenario(30)
+@scenario(weight=30)
 async def scenario_three(session):
     somedata = json.dumps({'OK': 1})
     async with session.post(_API, data=somedata) as resp:

--- a/molotov/tests/example2.py
+++ b/molotov/tests/example2.py
@@ -4,7 +4,7 @@ from molotov import scenario
 _API = 'http://localhost:8080'
 
 
-@scenario(40)
+@scenario(weight=40)
 async def scenario_one(session):
     async with session.get(_API) as resp:
         res = await resp.json()
@@ -12,7 +12,7 @@ async def scenario_one(session):
         assert resp.status == 200
 
 
-@scenario(60)
+@scenario(weight=60)
 async def scenario_two(session):
     async with session.get(_API) as resp:
         assert resp.status == 200

--- a/molotov/tests/example3.py
+++ b/molotov/tests/example3.py
@@ -6,6 +6,6 @@ def init_test(args):
     raise Exception("BAM")
 
 
-@scenario(100)
+@scenario(weight=100)
 async def fail(session):
     raise Exception("I am failing")

--- a/molotov/tests/test_api.py
+++ b/molotov/tests/test_api.py
@@ -5,11 +5,11 @@ from molotov.tests.support import TestLoop, async_test
 class TestUtil(TestLoop):
     def test_pick_scenario(self):
 
-        @scenario(10)
+        @scenario(weight=10)
         async def _one(self):
             pass
 
-        @scenario(90)
+        @scenario(weight=90)
         async def _two(self):
             pass
 
@@ -23,7 +23,7 @@ class TestUtil(TestLoop):
         async def _setup(self):
             pass
 
-        @scenario(10)
+        @scenario(weight=10)
         async def _one(self):
             pass
 
@@ -34,11 +34,11 @@ class TestUtil(TestLoop):
         await _setup(self)
 
     def test_no_scenario(self):
-        @scenario(0)
+        @scenario(weight=0)
         async def _one(self):
             pass
 
-        @scenario(0)
+        @scenario(weight=0)
         async def _two(self):
             pass
 
@@ -46,7 +46,7 @@ class TestUtil(TestLoop):
 
     def test_scenario_not_coroutine(self):
         try:
-            @scenario(1)
+            @scenario(weight=1)
             def _one(self):
                 pass
         except TypeError:
@@ -59,7 +59,7 @@ class TestUtil(TestLoop):
             def _setup(self):
                 pass
 
-            @scenario(90)
+            @scenario(weight=90)
             async def _two(self):
                 pass
         except TypeError:
@@ -76,7 +76,7 @@ class TestUtil(TestLoop):
             async def _setup2(self):
                 pass
 
-            @scenario(90)
+            @scenario(weight=90)
             async def _two(self):
                 pass
         except ValueError:

--- a/molotov/tests/test_fmwk.py
+++ b/molotov/tests/test_fmwk.py
@@ -25,11 +25,11 @@ class TestFmwk(TestLoop):
     async def test_step(self, loop):
         res = []
 
-        @scenario(0)
+        @scenario(weight=0)
         async def test_one(session):
             res.append('1')
 
-        @scenario(100)
+        @scenario(weight=100)
         async def test_two(session):
             res.append('2')
 
@@ -42,7 +42,7 @@ class TestFmwk(TestLoop):
     @async_test
     async def test_failing_step(self, loop):
 
-        @scenario(100)
+        @scenario(weight=100)
         async def test_two(session):
             raise ValueError()
 
@@ -60,11 +60,11 @@ class TestFmwk(TestLoop):
         async def setuptest(num, args):
             res.append('0')
 
-        @scenario(50)
+        @scenario(weight=50)
         async def test_one(session):
             pass
 
-        @scenario(100)
+        @scenario(weight=100)
         async def test_two(session):
             pass
 
@@ -95,11 +95,11 @@ class TestFmwk(TestLoop):
         async def setuptest(num, args):
             res.append('0')
 
-        @scenario(50)
+        @scenario(weight=50)
         async def test_one(session):
             pass
 
-        @scenario(100)
+        @scenario(weight=100)
         async def test_two(session):
             pass
 
@@ -133,11 +133,11 @@ class TestFmwk(TestLoop):
             async def setuptest(num, args):
                 res.append('0')
 
-        @scenario(50)
+        @scenario(weight=50)
         async def test_one(session):
             pass
 
-        @scenario(100)
+        @scenario(weight=100)
         async def test_two(session):
             pass
 
@@ -163,11 +163,11 @@ class TestFmwk(TestLoop):
         async def setuptest(num, args):
             res.append('0')
 
-        @scenario(50)
+        @scenario(weight=50)
         async def test_one(session):
             pass
 
-        @scenario(100)
+        @scenario(weight=100)
         async def test_two(session):
             pass
 
@@ -186,7 +186,7 @@ class TestFmwk(TestLoop):
     @async_test
     async def test_failure(self, loop):
 
-        @scenario(100)
+        @scenario(weight=100)
         async def test_failing(session):
             raise ValueError()
 
@@ -212,7 +212,7 @@ class TestFmwk(TestLoop):
         def _teardown():
             res.append('BYE')
 
-        @scenario(100)
+        @scenario(weight=100)
         async def test_two(session):
             os.kill(os.getpid(), signal.SIGTERM)
 
@@ -234,7 +234,7 @@ class TestFmwk(TestLoop):
         def _teardown():
             raise Exception('bleh')
 
-        @scenario(100)
+        @scenario(weight=100)
         async def test_two(session):
             os.kill(os.getpid(), signal.SIGTERM)
 
@@ -254,7 +254,7 @@ class TestFmwk(TestLoop):
         def _teardown():
             raise Exception('bleh')
 
-        @scenario(100)
+        @scenario(weight=100)
         async def test_two(session):
             os.kill(os.getpid(), signal.SIGTERM)
 
@@ -269,7 +269,7 @@ class TestFmwk(TestLoop):
         async def _worker_setup(num, args):
             raise Exception('bleh')
 
-        @scenario(100)
+        @scenario(weight=100)
         async def test_two(session):
             os.kill(os.getpid(), signal.SIGTERM)
 
@@ -284,7 +284,7 @@ class TestFmwk(TestLoop):
         def _setup(args):
             raise Exception('bleh')
 
-        @scenario(100)
+        @scenario(weight=100)
         async def test_two(session):
             os.kill(os.getpid(), signal.SIGTERM)
 
@@ -298,7 +298,7 @@ class TestFmwk(TestLoop):
         async def _worker_setup(num, args):
             return 1
 
-        @scenario(100)
+        @scenario(weight=100)
         async def test_two(session):
             os.kill(os.getpid(), signal.SIGTERM)
 

--- a/molotov/tests/test_run.py
+++ b/molotov/tests/test_run.py
@@ -33,13 +33,13 @@ class TestRunner(TestLoop):
             grab_json = json_request('http://localhost:8888/molotov.json')
             self.assertTrue('molotov' in grab_json['content'])
 
-        @scenario(10)
+        @scenario(weight=10)
         async def here_one(session):
             async with session.get('http://localhost:8888') as resp:
                 await resp.text()
             _RES.append(1)
 
-        @scenario(90)
+        @scenario(weight=90)
         async def here_two(session):
             if session.statsd is not None:
                 session.statsd.incr('yopla')
@@ -139,7 +139,7 @@ class TestRunner(TestLoop):
     @dedicatedloop
     def test_config_no_single_mode_found(self):
 
-        @scenario(10)
+        @scenario(weight=10)
         async def not_me(session):
             _RES.append(3)
 
@@ -151,7 +151,7 @@ class TestRunner(TestLoop):
     @dedicatedloop
     def test_single_mode(self):
 
-        @scenario(10)
+        @scenario(weight=10)
         async def here_three(session):
             _RES.append(3)
 


### PR DESCRIPTION
When reading the examples to learn about Molotov, it was not obvious to me what the numeric argument to the @scenario() decorator was.

I hope making it explicit will help people understand this more quickly.