### PR TITLE
Add a way to record requests and responses - Fixes #80

### DIFF
--- a/docs/source/events.rst
+++ b/docs/source/events.rst
@@ -1,0 +1,23 @@
+.. _events:
+
+Events
+======
+
+You can register one or several functions to receive events
+emited during the load test. You just need to decorate the function
+with the :func:`molotov.events` fixture described below:
+
+.. autofunction:: molotov.events
+
+Current supported events and their keyword arguments:
+
+- **sending_request**: session, request
+- **response_received**: session, response
+
+The framework will gradually get more events triggered from
+every step in the load test cycle.
+
+In the example below, all events are printed out:
+
+.. literalinclude:: ../../molotov/tests/example5.py
+

--- a/docs/source/fixtures.rst
+++ b/docs/source/fixtures.rst
@@ -21,11 +21,17 @@ test fixtures can be used to run functions at various stages.
 .. image:: _static/lifecycle.jpg
 
 
+Notice that the :func:`session_events` decorator is not displayed on the
+diagram. This particular decorator receives events emited by the session.
+
+
 .. autofunction:: molotov.global_setup
 
 .. autofunction:: molotov.setup
 
 .. autofunction:: molotov.setup_session
+
+.. autofunction:: molotov.session_events
 
 .. autofunction:: molotov.teardown_session
 

--- a/docs/source/fixtures.rst
+++ b/docs/source/fixtures.rst
@@ -21,17 +21,11 @@ test fixtures can be used to run functions at various stages.
 .. image:: _static/lifecycle.jpg
 
 
-Notice that the :func:`session_events` decorator is not displayed on the
-diagram. This particular decorator receives events emited by the session.
-
-
 .. autofunction:: molotov.global_setup
 
 .. autofunction:: molotov.setup
 
 .. autofunction:: molotov.setup_session
-
-.. autofunction:: molotov.session_events
 
 .. autofunction:: molotov.teardown_session
 
@@ -43,4 +37,3 @@ diagram. This particular decorator receives events emited by the session.
 Here's a full example, in order of calls:
 
 .. literalinclude:: ../../molotov/tests/example4.py
-

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -62,6 +62,7 @@ Check out the detailed documentation:
    installation
    fixtures
    helpers
+   events
    cli
    slave
    docker

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -6,12 +6,3 @@ Make sure you are using Python 3.5+ with Pip installed, then:
 .. code-block:: bash
 
    $ pip install molotov
-
-
-If you want to use statsd, you need to install `aiomeasures <https://pypi.python.org/pypi/aiomeasures>`_
-with:
-
-.. code-block:: bash
-
-   $ pip install aiomeasures
-

--- a/molotov/__init__.py
+++ b/molotov/__init__.py
@@ -1,7 +1,8 @@
 try:
     from molotov.api import (scenario, setup, global_setup, teardown,  # NOQA
                              global_teardown, setup_session,           # NOQA
-                             teardown_session, scenario_picker)        # NOQA
+                             teardown_session, scenario_picker,        # NOQA
+                             session_events)                           # NOQA
     from molotov.util import request, json_request                     # NOQA
     from molotov.util import set_var, get_var                          # NOQA
 except ImportError:

--- a/molotov/__init__.py
+++ b/molotov/__init__.py
@@ -2,7 +2,7 @@ try:
     from molotov.api import (scenario, setup, global_setup, teardown,  # NOQA
                              global_teardown, setup_session,           # NOQA
                              teardown_session, scenario_picker,        # NOQA
-                             session_events)                           # NOQA
+                             events)                                   # NOQA
     from molotov.util import request, json_request                     # NOQA
     from molotov.util import set_var, get_var                          # NOQA
 except ImportError:

--- a/molotov/api.py
+++ b/molotov/api.py
@@ -106,7 +106,7 @@ def _fixture(name, coroutine=True, multiple=False):
             raise ValueError("You can't have two %r functions" % name)
         if multiple:
             if name in _FIXTURES:
-                _FIXTURES[name] += func
+                _FIXTURES[name].append(func)
             else:
                 _FIXTURES[name] = [func]
         else:

--- a/molotov/api.py
+++ b/molotov/api.py
@@ -165,7 +165,7 @@ def teardown():
 
 
 def global_teardown():
-    """Called when everythin is done.
+    """Called when everything is done.
 
     *The decorated function should not be a coroutine.*
     """
@@ -203,3 +203,22 @@ def teardown_session():
     *The decorated function should be a coroutine.*
     """
     return _fixture('teardown_session')
+
+
+def session_events():
+    """Called everytime a request or a response is sent or received
+
+    Arguments received by the decorated function:
+
+    - **session** the :class:`aoihttp.ClienSession` instance
+    - **event** Name of the event
+    - + extra argument(s) specific to the event
+
+    Current supported events and their extra arguments:
+    - sending_request, request
+    - response_received, response
+
+    *The decorated function should be a coroutine.*
+    *IMPORTANT This function will directly impact the load test performances*
+    """
+    return _fixture('session_events')

--- a/molotov/api.py
+++ b/molotov/api.py
@@ -206,7 +206,7 @@ def teardown_session():
 
 
 def session_events():
-    """Called everytime a request or a response is sent or received
+    """Called everytime a session sends an event
 
     Arguments received by the decorated function:
 

--- a/molotov/listeners.py
+++ b/molotov/listeners.py
@@ -9,8 +9,9 @@ _COMPRESSED = ('gzip', 'compress', 'deflate', 'identity', 'br')
 
 class BaseListener(object):
     async def __call__(self, session, event, **options):
-        attr = getattr(self, 'on_' + event)
-        await attr(**options)
+        attr = getattr(self, 'on_' + event, None)
+        if attr is not None:
+            await attr(**options)
 
 
 class StdoutListener(BaseListener):

--- a/molotov/listeners.py
+++ b/molotov/listeners.py
@@ -8,7 +8,7 @@ _COMPRESSED = ('gzip', 'compress', 'deflate', 'identity', 'br')
 
 
 class BaseListener(object):
-    async def __call__(self, session, event, **options):
+    async def __call__(self, event, **options):
         attr = getattr(self, 'on_' + event, None)
         if attr is not None:
             await attr(**options)
@@ -39,7 +39,7 @@ class StdoutListener(BaseListener):
 
         return body
 
-    async def on_sending_request(self, request):
+    async def on_sending_request(self, session, request):
         if self.verbose < 2:
             return
         raw = '>' * 45
@@ -55,7 +55,7 @@ class StdoutListener(BaseListener):
 
         self.console.print(raw)
 
-    async def on_response_received(self, response):
+    async def on_response_received(self, session, response):
         if self.verbose < 2:
             return
         raw = '\n' + '=' * 45 + '\n'
@@ -85,5 +85,5 @@ class CustomListener(object):
     def __init__(self, fixture):
         self.fixture = fixture
 
-    async def __call__(self, session, event, **options):
-        await self.fixture(session, event, **options)
+    async def __call__(self, event, **options):
+        await self.fixture(event, **options)

--- a/molotov/listeners.py
+++ b/molotov/listeners.py
@@ -1,0 +1,88 @@
+import io
+
+
+_UNREADABLE = "***WARNING: Molotov can't display this body***"
+_BINARY = "**** Binary content ****"
+_FILE = "**** File content ****"
+_COMPRESSED = ('gzip', 'compress', 'deflate', 'identity', 'br')
+
+
+class BaseListener(object):
+    async def __call__(self, session, event, **options):
+        attr = getattr(self, 'on_' + event)
+        await attr(**options)
+
+
+class StdoutListener(BaseListener):
+    def __init__(self, **options):
+        self.verbose = options.get('verbose', 0)
+        self.console = options['console']
+
+    def _body2str(self, body):
+        try:
+            from aiohttp.payload import Payload
+        except ImportError:
+            Payload = None
+
+        if Payload is not None and isinstance(body, Payload):
+            body = body._value
+
+        if isinstance(body, io.IOBase):
+            return _FILE
+
+        if not isinstance(body, str):
+            try:
+                body = str(body, 'utf8')
+            except UnicodeDecodeError:
+                return _UNREADABLE
+
+        return body
+
+    async def on_sending_request(self, request):
+        if self.verbose < 2:
+            return
+        raw = '>' * 45
+        raw += '\n' + request.method + ' ' + str(request.url)
+        if len(request.headers) > 0:
+            headers = '\n'.join('%s: %s' % (k, v) for k, v in
+                                request.headers.items())
+            raw += '\n' + headers
+        if request.headers.get('Content-Encoding') in _COMPRESSED:
+            raw += '\n\n' + _BINARY + '\n'
+        elif request.body:
+            raw += '\n\n' + self._body2str(request.body) + '\n'
+
+        self.console.print(raw)
+
+    async def on_response_received(self, response):
+        if self.verbose < 2:
+            return
+        raw = '\n' + '=' * 45 + '\n'
+        raw += 'HTTP/1.1 %d %s\n' % (response.status, response.reason)
+        items = response.headers.items()
+        headers = '\n'.join('{}: {}'.format(k, v) for k, v in items)
+        raw += headers
+        if response.headers.get('Content-Encoding') in _COMPRESSED:
+            raw += '\n\n' + _BINARY
+        elif response.content:
+            content = await response.content.read()
+            if len(content) > 0:
+                # put back the data in the content
+                response.content.unread_data(content)
+                try:
+                    raw += '\n\n' + content.decode()
+                except UnicodeDecodeError:
+                    raw += '\n\n' + _UNREADABLE
+            else:
+                raw += '\n\n'
+
+        raw += '\n' + '<' * 45 + '\n'
+        self.console.print(raw)
+
+
+class CustomListener(object):
+    def __init__(self, fixture):
+        self.fixture = fixture
+
+    async def __call__(self, session, event, **options):
+        await self.fixture(session, event, **options)

--- a/molotov/session.py
+++ b/molotov/session.py
@@ -42,9 +42,10 @@ class LoggedClientSession(ClientSession):
         self.statsd = statsd
         self.listeners = [StdoutListener(verbose=self.verbose,
                                          console=self.console)]
-        session_events = get_fixture('session_events')
-        if session_events is not None:
-            self.add_listener(CustomListener(session_events))
+        listeners = get_fixture('events')
+        if listeners is not None:
+            for listener in listeners:
+                self.add_listener(CustomListener(listener))
 
     def add_listener(self, listener):
         self.listeners.append(listener)
@@ -52,7 +53,7 @@ class LoggedClientSession(ClientSession):
     async def send_event(self, event, **options):
         for listener in self.listeners:
             try:
-                await listener(self, event, **options)
+                await listener(event, session=self, **options)
             except Exception as e:
                 self.console.print_error(e)
 

--- a/molotov/session.py
+++ b/molotov/session.py
@@ -1,17 +1,15 @@
-import io
 import socket
 from urllib.parse import urlparse
 import asyncio
 from aiohttp.client import ClientSession, ClientRequest
 from aiohttp import TCPConnector
+
 from molotov.util import resolve
+from molotov.listeners import StdoutListener, CustomListener
+from molotov.api import get_fixture
 
 
 _HOST = socket.gethostname()
-_UNREADABLE = "***WARNING: Molotov can't display this body***"
-_BINARY = "**** Binary content ****"
-_FILE = "**** File content ****"
-_COMPRESSED = ('gzip', 'compress', 'deflate', 'identity', 'br')
 
 
 class LoggedClientRequest(ClientRequest):
@@ -20,9 +18,9 @@ class LoggedClientRequest(ClientRequest):
     session = None
 
     def send(self, *args, **kw):
-        if self.session and self.verbose > 1:
-            info = self.session.print_request(self)
-            asyncio.ensure_future(info)
+        if self.session:
+            event = self.session.send_event('sending_request', request=self)
+            asyncio.ensure_future(event)
         return super(LoggedClientRequest, self).send(*args, **kw)
 
 
@@ -42,6 +40,21 @@ class LoggedClientSession(ClientSession):
         self.verbose = verbose
         self.request_class.session = self
         self.statsd = statsd
+        self.listeners = [StdoutListener(verbose=self.verbose,
+                                         console=self.console)]
+        session_events = get_fixture('session_events')
+        if session_events is not None:
+            self.add_listener(CustomListener(session_events))
+
+    def add_listener(self, listener):
+        self.listeners.append(listener)
+
+    async def send_event(self, event, **options):
+        for listener in self.listeners:
+            try:
+                await listener(self, event, **options)
+            except Exception as e:
+                self.console.print_error(e)
 
     def _dns_lookup(self, url):
         return resolve(url)[0]
@@ -75,68 +88,5 @@ class LoggedClientSession(ClientSession):
         else:
             resp = await req(*args, **kw)
 
-        await self.print_response(resp)
+        await self.send_event('response_received', response=resp)
         return resp
-
-    def _body2str(self, body):
-        try:
-            from aiohttp.payload import Payload
-        except ImportError:
-            Payload = None
-
-        if Payload is not None and isinstance(body, Payload):
-            body = body._value
-
-        if isinstance(body, io.IOBase):
-            return _FILE
-
-        if not isinstance(body, str):
-            try:
-                body = str(body, 'utf8')
-            except UnicodeDecodeError:
-                return _UNREADABLE
-
-        return body
-
-    async def print_request(self, req):
-        if self.verbose < 2:
-            return
-
-        raw = '>' * 45
-        raw += '\n' + req.method + ' ' + str(req.url)
-        if len(req.headers) > 0:
-            headers = '\n'.join('%s: %s' % (k, v) for k, v in
-                                req.headers.items())
-            raw += '\n' + headers
-
-        if req.headers.get('Content-Encoding') in _COMPRESSED:
-            raw += '\n\n' + _BINARY + '\n'
-        elif req.body:
-            raw += '\n\n' + self._body2str(req.body) + '\n'
-
-        self.console.print(raw)
-
-    async def print_response(self, resp):
-        if self.verbose < 2:
-            return
-        raw = '\n' + '=' * 45 + '\n'
-        raw += 'HTTP/1.1 %d %s\n' % (resp.status, resp.reason)
-        items = resp.headers.items()
-        headers = '\n'.join('{}: {}'.format(k, v) for k, v in items)
-        raw += headers
-        if resp.headers.get('Content-Encoding') in _COMPRESSED:
-            raw += '\n\n' + _BINARY
-        elif resp.content:
-            content = await resp.content.read()
-            if len(content) > 0:
-                # put back the data in the content
-                resp.content.unread_data(content)
-                try:
-                    raw += '\n\n' + content.decode()
-                except UnicodeDecodeError:
-                    raw += '\n\n' + _UNREADABLE
-            else:
-                raw += '\n\n'
-
-        raw += '\n' + '<' * 45 + '\n'
-        self.console.print(raw)

--- a/molotov/sharedconsole.py
+++ b/molotov/sharedconsole.py
@@ -1,12 +1,10 @@
 import sys
-import traceback
-from io import StringIO
 import asyncio
 import multiprocessing
 import os
 from queue import Empty
 
-from molotov.util import cancellable_sleep
+from molotov.util import cancellable_sleep, printable_error
 
 
 class SharedConsole(object):
@@ -61,14 +59,8 @@ class SharedConsole(object):
         self._stream.put_nowait(line)
 
     def print_error(self, error, tb=None):
-        self.print(repr(error))
-        if tb is None:
-            tb = sys.exc_info()[2]
-        printed = StringIO()
-        traceback.print_tb(tb, file=printed)
-        printed.seek(0)
-        for line in printed.readlines():
-            self.print(line, end='')
+        for line in printable_error(error, tb):
+            self.print(line)
 
     def print_block(self, start, callable, end='OK'):
         if os.getpid() != self._creator:

--- a/molotov/tests/example4.py
+++ b/molotov/tests/example4.py
@@ -11,11 +11,6 @@ class SomeObject(object):
         pass
 
 
-@molotov.session_events()
-async def event(session, event, **data):
-    print(event)
-
-
 @molotov.global_setup()
 def init_test(args):
     molotov.set_var('SomeHeader', '1')

--- a/molotov/tests/example4.py
+++ b/molotov/tests/example4.py
@@ -2,13 +2,18 @@ import molotov
 
 
 class SomeObject(object):
-    """Does something smart in real lif with the async loop.
+    """Does something smart in real life with the async loop.
     """
     def __init__(self, loop):
         self.loop = loop
 
     def cleanup(self):
         pass
+
+
+@molotov.session_events()
+async def event(session, event, **data):
+    print(event)
 
 
 @molotov.global_setup()

--- a/molotov/tests/example5.py
+++ b/molotov/tests/example5.py
@@ -2,8 +2,15 @@ import molotov
 
 
 @molotov.events()
-async def event(event, **info):
-    print(event, info)
+async def print_request(event, **info):
+    if event == 'sending_request':
+        print("=>")
+
+
+@molotov.events()
+async def print_response(event, **info):
+    if event == 'response_received':
+        print('<=')
 
 
 @molotov.scenario(100)

--- a/molotov/tests/example5.py
+++ b/molotov/tests/example5.py
@@ -1,0 +1,14 @@
+import molotov
+
+
+@molotov.events()
+async def event(event, **info):
+    print(event, info)
+
+
+@molotov.scenario(100)
+async def scenario_one(session):
+    async with session.get('http://localhost:8080') as resp:
+        res = await resp.json()
+        assert res['result'] == 'OK'
+        assert resp.status == 200

--- a/molotov/tests/support.py
+++ b/molotov/tests/support.py
@@ -182,6 +182,8 @@ class TestLoop(unittest.TestCase):
         args.sizing = False
         args.sizing_tolerance = .0
         args.console_update = 0
+        args.use_extension = []
+
         if console is None:
             console = SharedConsole(interval=0)
         args.shared_console = console

--- a/molotov/tests/test_fmwk.py
+++ b/molotov/tests/test_fmwk.py
@@ -5,7 +5,7 @@ from molotov.runner import Runner
 from molotov.worker import Worker
 from molotov.api import (scenario, setup, global_setup, teardown,
                          global_teardown, setup_session, teardown_session,
-                         scenario_picker, session_events)
+                         scenario_picker, events)
 from molotov.tests.support import (TestLoop, async_test, dedicatedloop,
                                    serialize, catch_sleep, coserver)
 
@@ -107,11 +107,11 @@ class TestFmwk(TestLoop):
 
     def _runner(self, console, screen=None):
         res = []
-        events = []
+        _events = []
 
-        @session_events()
-        async def _events(session, event, **data):
-            events.append(event)
+        @events()
+        async def _event(event, **data):
+            _events.append(event)
 
         @global_setup()
         def init(args):
@@ -148,7 +148,7 @@ class TestFmwk(TestLoop):
         self.assertTrue(results['OK'] > 0)
         self.assertEqual(results['FAILED'], 0)
         self.assertEqual(res, ['SETUP', '0', 'SESSION', 'SESSION_TEARDOWN'])
-        self.assertTrue(len(events) > 0)
+        self.assertTrue(len(_events) > 0)
 
     @dedicatedloop
     def test_runner(self):

--- a/molotov/tests/test_fmwk.py
+++ b/molotov/tests/test_fmwk.py
@@ -5,9 +5,9 @@ from molotov.runner import Runner
 from molotov.worker import Worker
 from molotov.api import (scenario, setup, global_setup, teardown,
                          global_teardown, setup_session, teardown_session,
-                         scenario_picker)
+                         scenario_picker, session_events)
 from molotov.tests.support import (TestLoop, async_test, dedicatedloop,
-                                   serialize, catch_sleep)
+                                   serialize, catch_sleep, coserver)
 
 
 class TestFmwk(TestLoop):
@@ -107,6 +107,11 @@ class TestFmwk(TestLoop):
 
     def _runner(self, console, screen=None):
         res = []
+        events = []
+
+        @session_events()
+        async def _events(session, event, **data):
+            events.append(event)
 
         @global_setup()
         def init(args):
@@ -123,11 +128,13 @@ class TestFmwk(TestLoop):
 
         @scenario(weight=50)
         async def test_one(session):
-            pass
+            async with session.get('http://localhost:8888') as resp:
+                await resp.text()
 
         @scenario(weight=100)
         async def test_two(session):
-            pass
+            async with session.get('http://localhost:8888') as resp:
+                await resp.text()
 
         @teardown_session()
         async def _teardown_session(wid, session):
@@ -141,14 +148,17 @@ class TestFmwk(TestLoop):
         self.assertTrue(results['OK'] > 0)
         self.assertEqual(results['FAILED'], 0)
         self.assertEqual(res, ['SETUP', '0', 'SESSION', 'SESSION_TEARDOWN'])
+        self.assertTrue(len(events) > 0)
 
     @dedicatedloop
     def test_runner(self):
-        return self._runner(console=False)
+        with coserver():
+            return self._runner(console=False)
 
     @dedicatedloop
     def test_runner_console(self):
-        return self._runner(console=True)
+        with coserver():
+            return self._runner(console=True)
 
     @dedicatedloop
     def _multiprocess(self, console, nosetup=False):

--- a/molotov/tests/test_run.py
+++ b/molotov/tests/test_run.py
@@ -325,7 +325,7 @@ class TestRunner(TestLoop):
                                                 'molotov.tests.test_run')
 
             ratio = float(_RES2['fail']) / float(_RES2['succ']) * 100.
-            self.assertTrue(ratio < 10. and ratio >= 5., ratio)
+            self.assertTrue(ratio < 15. and ratio >= 5., ratio)
 
     @dedicatedloop
     def test_sizing_multiprocess(self):

--- a/molotov/tests/test_run.py
+++ b/molotov/tests/test_run.py
@@ -14,7 +14,8 @@ from molotov.util import request, json_request, set_timer
 from molotov import __version__
 
 
-_CONFIG = os.path.join(os.path.dirname(__file__), 'molotov.json')
+_HERE = os.path.dirname(__file__)
+_CONFIG = os.path.join(_HERE, 'molotov.json')
 _RES = []
 _RES2 = {}
 
@@ -387,7 +388,7 @@ class TestRunner(TestLoop):
                                                 'molotov.tests.test_run')
 
             ratio = float(_RES2['fail']) / float(_RES2['succ']) * 100.
-            self.assertTrue(ratio < 15. and ratio > 5., ratio)
+            self.assertTrue(ratio < 20. and ratio > 5., ratio)
 
     @dedicatedloop
     def test_sizing_multiprocess_interrupted(self):
@@ -413,3 +414,73 @@ class TestRunner(TestLoop):
                                             '-s', 'sizer',
                                             'molotov.tests.test_run')
         self.assertTrue("Sizing was not finished" in stdout)
+
+    @dedicatedloop
+    def test_use_extension(self):
+        ext = os.path.join(_HERE, 'example5.py')
+
+        @scenario(weight=10)
+        async def simpletest(session):
+            async with session.get('http://localhost:8888') as resp:
+                assert resp.status == 200
+
+        with coserver():
+            stdout, stderr = self._test_molotov('-cx', '--max-runs', '1',
+                                                '--use-extension=' + ext,
+                                                '-s',
+                                                'simpletest',
+                                                'molotov.tests.test_run')
+        self.assertTrue("=>" in stdout)
+        self.assertTrue("<=" in stdout)
+
+    @dedicatedloop
+    def test_use_extension_fail(self):
+        ext = os.path.join(_HERE, 'exampleIDONTEXIST.py')
+
+        @scenario(weight=10)
+        async def simpletest(session):
+            async with session.get('http://localhost:8888') as resp:
+                assert resp.status == 200
+
+        with coserver():
+            stdout, stderr = self._test_molotov('-cx', '--max-runs', '1',
+                                                '--use-extension=' + ext,
+                                                '-s',
+                                                'simpletest',
+                                                'molotov.tests.test_run')
+        self.assertTrue("Cannot import" in stdout)
+
+    @dedicatedloop
+    def test_use_extension_module_name(self):
+        ext = 'molotov.tests.example5'
+
+        @scenario(weight=10)
+        async def simpletest(session):
+            async with session.get('http://localhost:8888') as resp:
+                assert resp.status == 200
+
+        with coserver():
+            stdout, stderr = self._test_molotov('-cx', '--max-runs', '1',
+                                                '--use-extension=' + ext,
+                                                '-s',
+                                                'simpletest',
+                                                'molotov.tests.test_run')
+        self.assertTrue("=>" in stdout)
+        self.assertTrue("<=" in stdout)
+
+    @dedicatedloop
+    def test_use_extension_module_name_fail(self):
+        ext = 'IDONTEXTSIST'
+
+        @scenario(weight=10)
+        async def simpletest(session):
+            async with session.get('http://localhost:8888') as resp:
+                assert resp.status == 200
+
+        with coserver():
+            stdout, stderr = self._test_molotov('-cx', '--max-runs', '1',
+                                                '--use-extension=' + ext,
+                                                '-s',
+                                                'simpletest',
+                                                'molotov.tests.test_run')
+        self.assertTrue("Cannot import" in stdout)

--- a/molotov/tests/test_session.py
+++ b/molotov/tests/test_session.py
@@ -17,7 +17,7 @@ class TestLoggedClientSession(TestLoop):
     @async_test
     async def test_add_buggy_listener(self, loop, console, results):
         class MyListener(BaseListener):
-            def on_response_received(self, response):
+            def on_response_received(self, **options):
                 raise Exception("Bam")
 
         l = MyListener()
@@ -37,8 +37,8 @@ class TestLoggedClientSession(TestLoop):
             def __init__(self):
                 self.responses = []
 
-            def on_response_received(self, response):
-                self.responses.append(response)
+            def on_response_received(self, **options):
+                self.responses.append(options['response'])
 
         l = MyListener()
         async with self._get_session(loop, console,

--- a/molotov/tests/test_session.py
+++ b/molotov/tests/test_session.py
@@ -3,6 +3,7 @@ from aiohttp.client_reqrep import ClientRequest
 from yarl import URL
 from unittest.mock import patch
 
+from molotov.listeners import BaseListener
 import molotov.session
 from molotov.tests.support import coserver, Response
 from molotov.tests.support import TestLoop, async_test, serialize
@@ -14,12 +15,49 @@ class TestLoggedClientSession(TestLoop):
         return molotov.session.LoggedClientSession(*args, **kw)
 
     @async_test
+    async def test_add_buggy_listener(self, loop, console, results):
+        class MyListener(BaseListener):
+            def on_response_received(self, response):
+                raise Exception("Bam")
+
+        l = MyListener()
+        async with self._get_session(loop, console,
+                                     verbose=2) as session:
+            session.add_listener(l)
+            binary_body = b''
+            response = Response(body=binary_body)
+            await session.send_event('response_received', response=response)
+
+        resp = await serialize(console)
+        self.assertTrue("Bam" in resp)
+
+    @async_test
+    async def test_add_listener(self, loop, console, results):
+        class MyListener(BaseListener):
+            def __init__(self):
+                self.responses = []
+
+            def on_response_received(self, response):
+                self.responses.append(response)
+
+        l = MyListener()
+        async with self._get_session(loop, console,
+                                     verbose=2) as session:
+            session.add_listener(l)
+            binary_body = b''
+            response = Response(body=binary_body)
+            await session.send_event('response_received', response=response)
+
+        await serialize(console)
+        self.assertEqual(l.responses, [response])
+
+    @async_test
     async def test_empty_response(self, loop, console, results):
         async with self._get_session(loop, console,
                                      verbose=2) as session:
             binary_body = b''
             response = Response(body=binary_body)
-            await session.print_response(response)
+            await session.send_event('response_received', response=response)
 
         await serialize(console)
 
@@ -29,7 +67,7 @@ class TestLoggedClientSession(TestLoop):
                                      verbose=2) as session:
             binary_body = b'MZ\x90\x00\x03\x00\x00\x00\x04\x00'
             response = Response(body=binary_body)
-            await session.print_response(response)
+            await session.send_event('response_received', response=response)
 
         res = await serialize(console)
         wanted = "can't display this body"
@@ -51,10 +89,10 @@ class TestLoggedClientSession(TestLoop):
         async with self._get_session(loop, console,
                                      verbose=1) as session:
             req = ClientRequest('GET', URL('http://example.com'))
-            await session.print_request(req)
+            await session.send_event('sending_request', request=req)
 
             response = Response(body='')
-            await session.print_response(response)
+            await session.send_event('response_received', response=response)
 
         res = await serialize(console)
         self.assertEqual(res, '')
@@ -67,7 +105,7 @@ class TestLoggedClientSession(TestLoop):
             req = ClientRequest('GET', URL('http://example.com'),
                                 data=binary_body)
             req.headers['Content-Encoding'] = 'gzip'
-            await session.print_request(req)
+            await session.send_event('sending_request', request=req)
 
         res = await serialize(console)
         self.assertTrue("Binary" in res, res)
@@ -80,7 +118,7 @@ class TestLoggedClientSession(TestLoop):
                 req = ClientRequest('POST', URL('http://example.com'),
                                     data=f)
                 req.headers['Content-Encoding'] = 'something/bin'
-                await session.print_request(req)
+                await session.send_event('sending_request', request=req)
 
         res = await serialize(console)
         self.assertTrue("File" in res, res)
@@ -93,7 +131,7 @@ class TestLoggedClientSession(TestLoop):
                 req = ClientRequest('POST', URL('http://example.com'),
                                     data=f)
                 req.headers['Content-Encoding'] = 'something/bin'
-                await session.print_request(req)
+                await session.send_event('sending_request', request=req)
 
         res = await serialize(console)
         self.assertTrue("File" in res, res)
@@ -105,7 +143,7 @@ class TestLoggedClientSession(TestLoop):
             binary_body = gzip.compress(b'some gzipped data')
             response = Response(body=binary_body)
             response.headers['Content-Encoding'] = 'gzip'
-            await session.print_response(response)
+            await session.send_event('response_received', response=response)
 
         res = await serialize(console)
         self.assertTrue("Binary" in res, res)
@@ -117,7 +155,7 @@ class TestLoggedClientSession(TestLoop):
             binary_body = gzip.compress(b'some gzipped data')
             req = ClientRequest('GET', URL('http://example.com'),
                                 data=binary_body)
-            await session.print_request(req)
+            await session.send_event('sending_request', request=req)
 
         res = await serialize(console)
         self.assertTrue("display this body" in res, res)
@@ -139,7 +177,7 @@ class TestLoggedClientSession(TestLoop):
                 req = ClientRequest('GET', URL('http://example.com'),
                                     data=body)
                 req.body = req.body._value
-                await session.print_request(req)
+                await session.send_event('sending_request', request=req)
 
         res = await serialize(console)
         self.assertTrue("ok man" in res, res)

--- a/molotov/util.py
+++ b/molotov/util.py
@@ -1,3 +1,6 @@
+from io import StringIO
+import traceback
+import sys
 import functools
 import json
 import socket
@@ -235,3 +238,15 @@ def _make_sleep():
 
 
 cancellable_sleep = _make_sleep()
+
+
+def printable_error(error, tb=None):
+    printable = [repr(error)]
+    if tb is None:
+        tb = sys.exc_info()[2]
+    printed = StringIO()
+    traceback.print_tb(tb, file=printed)
+    printed.seek(0)
+    for line in printed.readlines():
+        printable.append(line.rstrip('\n'))
+    return printable


### PR DESCRIPTION
- [x] Make the session request response printer pluggable
- [x] add a "events" fixture so people can write their own backends
- [x] document the feature with an example
- [x] add a CLI option. --use-extension + tests
