### PR TITLE
Send the request with the 'response_received' event

### DIFF
--- a/docs/source/events.rst
+++ b/docs/source/events.rst
@@ -12,7 +12,7 @@ with the :func:`molotov.events` fixture described below:
 Current supported events and their keyword arguments:
 
 - **sending_request**: session, request
-- **response_received**: session, response
+- **response_received**: session, response, request
 
 The framework will gradually get more events triggered from
 every step in the load test cycle.

--- a/molotov/listeners.py
+++ b/molotov/listeners.py
@@ -55,7 +55,7 @@ class StdoutListener(BaseListener):
 
         self.console.print(raw)
 
-    async def on_response_received(self, session, response):
+    async def on_response_received(self, session, response, request):
         if self.verbose < 2:
             return
         raw = '\n' + '=' * 45 + '\n'

--- a/molotov/session.py
+++ b/molotov/session.py
@@ -1,7 +1,7 @@
 import socket
 from urllib.parse import urlparse
 import asyncio
-from aiohttp.client import ClientSession, ClientRequest
+from aiohttp.client import ClientSession, ClientRequest, ClientResponse
 from aiohttp import TCPConnector
 
 from molotov.util import resolve
@@ -26,6 +26,10 @@ class LoggedClientRequest(ClientRequest):
         return response
 
 
+class LoggedClientResponse(ClientResponse):
+    request = None
+
+
 class LoggedClientSession(ClientSession):
     """Session with printable requests and responses.
     """
@@ -34,13 +38,16 @@ class LoggedClientSession(ClientSession):
         if connector is None:
             connector = TCPConnector(loop=loop, limit=None)
         super(LoggedClientSession,
-              self).__init__(loop=loop, request_class=LoggedClientRequest,
+              self).__init__(loop=loop,
+                             request_class=LoggedClientRequest,
+                             response_class=LoggedClientResponse,
                              connector=connector,  **kw)
         self.console = console
         self.request_class = LoggedClientRequest
         self.request_class.verbose = verbose
         self.verbose = verbose
         self.request_class.session = self
+        self.request_class.response_class = LoggedClientResponse
         self.statsd = statsd
         self.listeners = [StdoutListener(verbose=self.verbose,
                                          console=self.console)]

--- a/molotov/session.py
+++ b/molotov/session.py
@@ -21,7 +21,9 @@ class LoggedClientRequest(ClientRequest):
         if self.session:
             event = self.session.send_event('sending_request', request=self)
             asyncio.ensure_future(event)
-        return super(LoggedClientRequest, self).send(*args, **kw)
+        response = super(LoggedClientRequest, self).send(*args, **kw)
+        response.request = self
+        return response
 
 
 class LoggedClientSession(ClientSession):
@@ -89,5 +91,5 @@ class LoggedClientSession(ClientSession):
         else:
             resp = await req(*args, **kw)
 
-        await self.send_event('response_received', response=resp)
+        await self.send_event('response_received', response=resp, request=resp.request)
         return resp

--- a/molotov/session.py
+++ b/molotov/session.py
@@ -98,5 +98,7 @@ class LoggedClientSession(ClientSession):
         else:
             resp = await req(*args, **kw)
 
-        await self.send_event('response_received', response=resp, request=resp.request)
+        await self.send_event('response_received',
+                              response=resp,
+                              request=resp.request)
         return resp

--- a/molotov/tests/support.py
+++ b/molotov/tests/support.py
@@ -16,12 +16,12 @@ import pytest
 from queue import Empty
 from unittest.mock import patch
 
-from aiohttp.client_reqrep import ClientResponse, URL
+from aiohttp.client_reqrep import URL
 from multidict import CIMultiDict
 from molotov.api import _SCENARIO, _FIXTURES
 from molotov import util
 from molotov.run import PYPY
-from molotov.session import LoggedClientRequest
+from molotov.session import LoggedClientRequest, LoggedClientResponse
 from molotov.sharedconsole import SharedConsole
 from molotov.sharedcounter import SharedCounters
 
@@ -126,7 +126,7 @@ def coserver(port=8888):
 
 
 def Response(method='GET', status=200, body=b'***'):
-    response = ClientResponse(method, URL('/'))
+    response = LoggedClientResponse(method, URL('/'))
     response.status = status
     response.reason = ''
     response.code = status

--- a/molotov/tests/support.py
+++ b/molotov/tests/support.py
@@ -21,6 +21,7 @@ from multidict import CIMultiDict
 from molotov.api import _SCENARIO, _FIXTURES
 from molotov import util
 from molotov.run import PYPY
+from molotov.session import LoggedClientRequest
 from molotov.sharedconsole import SharedConsole
 from molotov.sharedcounter import SharedCounters
 
@@ -148,6 +149,12 @@ def Response(method='GET', status=200, body=b'***'):
     response._content = body
 
     return response
+
+
+def Request(url="http://127.0.0.1/", method='GET', body=b'***'):
+    request = LoggedClientRequest(method, URL(url))
+    request.body = body
+    return request
 
 
 class TestLoop(unittest.TestCase):

--- a/molotov/tests/test_session.py
+++ b/molotov/tests/test_session.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from molotov.listeners import BaseListener
 import molotov.session
-from molotov.tests.support import coserver, Response
+from molotov.tests.support import coserver, Response, Request
 from molotov.tests.support import TestLoop, async_test, serialize
 
 
@@ -24,9 +24,10 @@ class TestLoggedClientSession(TestLoop):
         async with self._get_session(loop, console,
                                      verbose=2) as session:
             session.add_listener(l)
+            request = Request()
             binary_body = b''
             response = Response(body=binary_body)
-            await session.send_event('response_received', response=response)
+            await session.send_event('response_received', response=response, request=request)
 
         resp = await serialize(console)
         self.assertTrue("Bam" in resp)
@@ -44,9 +45,10 @@ class TestLoggedClientSession(TestLoop):
         async with self._get_session(loop, console,
                                      verbose=2) as session:
             session.add_listener(l)
+            request = Request()
             binary_body = b''
             response = Response(body=binary_body)
-            await session.send_event('response_received', response=response)
+            await session.send_event('response_received', response=response, request=request)
 
         await serialize(console)
         self.assertEqual(l.responses, [response])
@@ -55,9 +57,10 @@ class TestLoggedClientSession(TestLoop):
     async def test_empty_response(self, loop, console, results):
         async with self._get_session(loop, console,
                                      verbose=2) as session:
+            request = Request()
             binary_body = b''
             response = Response(body=binary_body)
-            await session.send_event('response_received', response=response)
+            await session.send_event('response_received', response=response, request=request)
 
         await serialize(console)
 
@@ -65,9 +68,10 @@ class TestLoggedClientSession(TestLoop):
     async def test_encoding(self, loop, console, results):
         async with self._get_session(loop, console,
                                      verbose=2) as session:
+            request = Request()
             binary_body = b'MZ\x90\x00\x03\x00\x00\x00\x04\x00'
             response = Response(body=binary_body)
-            await session.send_event('response_received', response=response)
+            await session.send_event('response_received', response=response, request=request)
 
         res = await serialize(console)
         wanted = "can't display this body"
@@ -92,7 +96,8 @@ class TestLoggedClientSession(TestLoop):
             await session.send_event('sending_request', request=req)
 
             response = Response(body='')
-            await session.send_event('response_received', response=response)
+            request = Request()
+            await session.send_event('response_received', response=response, request=request)
 
         res = await serialize(console)
         self.assertEqual(res, '')
@@ -140,10 +145,11 @@ class TestLoggedClientSession(TestLoop):
     async def test_gzipped_response(self, loop, console, results):
         async with self._get_session(loop, console,
                                      verbose=2) as session:
+            request = Request()
             binary_body = gzip.compress(b'some gzipped data')
             response = Response(body=binary_body)
             response.headers['Content-Encoding'] = 'gzip'
-            await session.send_event('response_received', response=response)
+            await session.send_event('response_received', response=response, request=request)
 
         res = await serialize(console)
         self.assertTrue("Binary" in res, res)

--- a/molotov/tests/test_session.py
+++ b/molotov/tests/test_session.py
@@ -27,7 +27,9 @@ class TestLoggedClientSession(TestLoop):
             request = Request()
             binary_body = b''
             response = Response(body=binary_body)
-            await session.send_event('response_received', response=response, request=request)
+            await session.send_event('response_received',
+                                     response=response,
+                                     request=request)
 
         resp = await serialize(console)
         self.assertTrue("Bam" in resp)
@@ -48,7 +50,9 @@ class TestLoggedClientSession(TestLoop):
             request = Request()
             binary_body = b''
             response = Response(body=binary_body)
-            await session.send_event('response_received', response=response, request=request)
+            await session.send_event('response_received',
+                                     response=response,
+                                     request=request)
 
         await serialize(console)
         self.assertEqual(l.responses, [response])
@@ -60,7 +64,9 @@ class TestLoggedClientSession(TestLoop):
             request = Request()
             binary_body = b''
             response = Response(body=binary_body)
-            await session.send_event('response_received', response=response, request=request)
+            await session.send_event('response_received',
+                                     response=response,
+                                     request=request)
 
         await serialize(console)
 
@@ -71,7 +77,9 @@ class TestLoggedClientSession(TestLoop):
             request = Request()
             binary_body = b'MZ\x90\x00\x03\x00\x00\x00\x04\x00'
             response = Response(body=binary_body)
-            await session.send_event('response_received', response=response, request=request)
+            await session.send_event('response_received',
+                                     response=response,
+                                     request=request)
 
         res = await serialize(console)
         wanted = "can't display this body"
@@ -97,7 +105,9 @@ class TestLoggedClientSession(TestLoop):
 
             response = Response(body='')
             request = Request()
-            await session.send_event('response_received', response=response, request=request)
+            await session.send_event('response_received',
+                                     response=response,
+                                     request=request)
 
         res = await serialize(console)
         self.assertEqual(res, '')
@@ -149,7 +159,9 @@ class TestLoggedClientSession(TestLoop):
             binary_body = gzip.compress(b'some gzipped data')
             response = Response(body=binary_body)
             response.headers['Content-Encoding'] = 'gzip'
-            await session.send_event('response_received', response=response, request=request)
+            await session.send_event('response_received',
+                                     response=response,
+                                     request=request)
 
         res = await serialize(console)
         self.assertTrue("Binary" in res, res)


### PR DESCRIPTION
This one should solve (at least partially) #84.

Right now, newly defined `LoggedClientResponse` class looks kind of empty, but in the future it can override it's parent methods and embed events/metrics into them.