### PR TITLE
Fix '--quiet' for single-process mode

### DIFF
--- a/molotov/run.py
+++ b/molotov/run.py
@@ -159,7 +159,8 @@ def run(args):
 
     if args.use_extension:
         for extension in args.use_extension:
-            print("Loading extension %r" % extension)
+            if not args.quiet:
+                print("Loading extension %r" % extension)
             if os.path.exists(extension):
                 spec = spec_from_file_location("extension", extension)
                 module = module_from_spec(spec)

--- a/molotov/runner.py
+++ b/molotov/runner.py
@@ -137,13 +137,12 @@ class Runner(object):
             self.console.print('**** RUNNING IN DEBUG MODE == SLOW ****')
             self.loop.set_debug(True)
 
-        if self.args.original_pid == os.getpid():
-            if not self.args.quiet:
-                fut = self._display_results(self.args.console_update)
-                update = self.ensure_future(fut)
-                display = self.ensure_future(self.console.display())
-                display = self.gather(update, display)
-                self._tasks.append(display)
+        if self.args.original_pid == os.getpid() and not self.args.quiet:
+            fut = self._display_results(self.args.console_update)
+            update = self.ensure_future(fut)
+            display = self.ensure_future(self.console.display())
+            display = self.gather(update, display)
+            self._tasks.append(display)
 
         workers = self.gather(*self._runner())
         workers.add_done_callback(lambda fut: stop())

--- a/molotov/runner.py
+++ b/molotov/runner.py
@@ -138,11 +138,12 @@ class Runner(object):
             self.loop.set_debug(True)
 
         if self.args.original_pid == os.getpid():
-            fut = self._display_results(self.args.console_update)
-            update = self.ensure_future(fut)
-            display = self.ensure_future(self.console.display())
-            display = self.gather(update, display)
-            self._tasks.append(display)
+            if not self.args.quiet:
+                fut = self._display_results(self.args.console_update)
+                update = self.ensure_future(fut)
+                display = self.ensure_future(self.console.display())
+                display = self.gather(update, display)
+                self._tasks.append(display)
 
         workers = self.gather(*self._runner())
         workers.add_done_callback(lambda fut: stop())

--- a/molotov/tests/test_run.py
+++ b/molotov/tests/test_run.py
@@ -206,6 +206,19 @@ class TestRunner(TestLoop):
         wanted = "SUCCESSES: 2"
         self.assertTrue(wanted in stdout)
 
+    @dedicatedloop
+    def test_quiet(self):
+
+        @scenario(weight=10)
+        async def here_three(session):
+            _RES.append(3)
+
+        stdout, stderr = self._test_molotov('-cx', '--max-runs', '1', '-q', '-s',
+                                            'here_three',
+                                            'molotov.tests.test_run')
+        self.assertEqual(stdout, '')
+        self.assertEqual(stderr, '')
+
     @only_pypy
     @dedicatedloop
     def test_uvloop_pypy(self):

--- a/molotov/tests/test_run.py
+++ b/molotov/tests/test_run.py
@@ -492,7 +492,8 @@ class TestRunner(TestLoop):
         async def here_three(session):
             _RES.append(3)
 
-        stdout, stderr = self._test_molotov('-cx', '--max-runs', '1', '-q', '-s',
+        stdout, stderr = self._test_molotov('-cx', '--max-runs', '1', '-s',
+                                            '-q',
                                             'here_three',
                                             'molotov.tests.test_run')
         self.assertEqual(stdout, '')

--- a/molotov/tests/test_run.py
+++ b/molotov/tests/test_run.py
@@ -206,19 +206,6 @@ class TestRunner(TestLoop):
         wanted = "SUCCESSES: 2"
         self.assertTrue(wanted in stdout)
 
-    @dedicatedloop
-    def test_quiet(self):
-
-        @scenario(weight=10)
-        async def here_three(session):
-            _RES.append(3)
-
-        stdout, stderr = self._test_molotov('-cx', '--max-runs', '1', '-q', '-s',
-                                            'here_three',
-                                            'molotov.tests.test_run')
-        self.assertEqual(stdout, '')
-        self.assertEqual(stderr, '')
-
     @only_pypy
     @dedicatedloop
     def test_uvloop_pypy(self):
@@ -497,3 +484,16 @@ class TestRunner(TestLoop):
                                                 'simpletest',
                                                 'molotov.tests.test_run')
         self.assertTrue("Cannot import" in stdout)
+
+    @dedicatedloop
+    def test_quiet(self):
+
+        @scenario(weight=10)
+        async def here_three(session):
+            _RES.append(3)
+
+        stdout, stderr = self._test_molotov('-cx', '--max-runs', '1', '-q', '-s',
+                                            'here_three',
+                                            'molotov.tests.test_run')
+        self.assertEqual(stdout, '')
+        self.assertEqual(stderr, '')

--- a/molotov/tests/test_run.py
+++ b/molotov/tests/test_run.py
@@ -492,8 +492,8 @@ class TestRunner(TestLoop):
         async def here_three(session):
             _RES.append(3)
 
-        stdout, stderr = self._test_molotov('-cx', '--max-runs', '1', '-s',
-                                            '-q',
+        stdout, stderr = self._test_molotov('-cx', '--max-runs', '1', '-q',
+                                            '-s',
                                             'here_three',
                                             'molotov.tests.test_run')
         self.assertEqual(stdout, '')


### PR DESCRIPTION
`--quiet` option wasn't working for single-process mode. Well, that's assuming i understand Molotov's multiprocessing correctly.

Anyway, here's the fix.

Test case should ensure this bug will be caught in the future, shall it appear again.