### PR TITLE
Introduce new events for extensions

### DIFF
--- a/docs/source/events.rst
+++ b/docs/source/events.rst
@@ -13,6 +13,9 @@ Current supported events and their keyword arguments:
 
 - **sending_request**: session, request
 - **response_received**: session, response, request
+- **current_workers**: workers
+- **scenario_success**: scenario
+- **scenario_failure**: scenario, exception
 
 The framework will gradually get more events triggered from
 every step in the load test cycle.

--- a/molotov/tests/example7.py
+++ b/molotov/tests/example7.py
@@ -1,0 +1,23 @@
+import molotov
+import time
+
+
+concurs = []  # [(timestamp, worker count)]
+
+
+def _now():
+    return time.time() * 1000
+
+
+@molotov.events()
+async def record_time(event, **info):
+    if event == 'current_workers':
+        concurs.append((_now(), info['workers']))
+
+
+@molotov.global_teardown()
+def display_average():
+    print("\nconcurrencies: %s", concurs)
+    delta = max(ts for ts, _ in concurs) - min(ts for ts, _ in concurs)
+    average = sum(value for _, value in concurs) * 1000 / delta
+    print("\nAverage concurrency: %.2f VU/s" % average)

--- a/molotov/tests/example8.py
+++ b/molotov/tests/example8.py
@@ -1,0 +1,23 @@
+import molotov
+import time
+
+
+@molotov.events()
+async def print_test_case(event, **info):
+    if event == 'scenario_success':
+        scenario = info['scenario']
+        print({
+            "ts": time.time(),
+            "type": "scenario_success",
+            "name": scenario['name'],
+        })
+    elif event == 'scenario_failure':
+        scenario = info['scenario']
+        exception = info['exception']
+        print({
+            "ts": time.time(),
+            "type": "scenario_failure",
+            "name": scenario['name'],
+            "exception": exception.__class__.__name__,
+            "errorMessage": str(exception),
+        })

--- a/molotov/tests/test_listeners.py
+++ b/molotov/tests/test_listeners.py
@@ -1,0 +1,37 @@
+from molotov.listeners import BaseListener, EventSender
+from molotov.tests.support import TestLoop, async_test, serialize
+
+
+class TestListeners(TestLoop):
+    @async_test
+    async def test_add_listener(self, loop, console, results):
+        class MyListener(BaseListener):
+            def __init__(self):
+                self.fired = False
+                self.value = None
+
+            def on_my_event(self, **options):
+                self.fired = True
+                self.value = options["value"]
+
+        listener = MyListener()
+        eventer = EventSender(console)
+        eventer.add_listener(listener)
+        await eventer.send_event("my_event", value=42)
+        await serialize(console)
+
+        self.assertTrue(listener.fired)
+        self.assertEqual(listener.value, 42)
+
+    @async_test
+    async def test_buggy_listener(self, loop, console, results):
+        class MyListener(BaseListener):
+            def on_my_event(self, **options):
+                raise Exception("Bam")
+
+        listener = MyListener()
+        eventer = EventSender(console)
+        eventer.add_listener(listener)
+        await eventer.send_event("my_event")
+        resp = await serialize(console)
+        self.assertTrue("Bam" in resp)

--- a/molotov/tests/test_run.py
+++ b/molotov/tests/test_run.py
@@ -281,7 +281,7 @@ class TestRunner(TestLoop):
                                                 'molotov.tests.test_run')
             wanted = "SUCCESSES: 2"
             self.assertTrue(wanted in stdout, stdout)
-            self.assertEqual(delay, [.1, .6] * 2)
+            self.assertEqual(delay, [1, .1, 1, .6, 1, .1, 1, .6, 1])
 
     @dedicatedloop
     def test_rampup(self):
@@ -301,7 +301,7 @@ class TestRunner(TestLoop):
             # the first one starts immediatly, then each worker
             # sleeps 2 seconds more.
             delay = [d for d in delay if d != 0]
-            self.assertEqual(delay, [2.0, 4.0, 6.0, 8.0])
+            self.assertEqual(delay, [1, 2.0, 4.0, 6.0, 8.0, 1, 1])
             wanted = "SUCCESSES: 10"
             self.assertTrue(wanted in stdout, stdout)
 
@@ -341,11 +341,18 @@ class TestRunner(TestLoop):
                 else:
                     counters['OK'] += 1
 
-            stdout, stderr = self._test_molotov('--sizing', '-p', '2',
-                                                '--sizing-tolerance', '5',
-                                                '--console-update', '0',
-                                                '-s', 'sizer',
-                                                'molotov.tests.test_run')
+            with set_args('molotov', '--sizing', '-p', '2',
+                          '--sizing-tolerance', '5',
+                          '--console-update', '0',
+                          '-s', 'sizer',
+                          'molotov.tests.test_run') as (stdout, stderr):
+                try:
+                    main()
+                except SystemExit:
+                    pass
+            stdout, stderr = stdout.read().strip(), stderr.read().strip()
+
+            # stdout, stderr = self._test_molotov()
             ratio = (float(counters['FAILED'].value) /
                      float(counters['OK'].value) * 100.)
             self.assertTrue(ratio >= 5., ratio)

--- a/molotov/tests/test_session.py
+++ b/molotov/tests/test_session.py
@@ -15,26 +15,6 @@ class TestLoggedClientSession(TestLoop):
         return molotov.session.LoggedClientSession(*args, **kw)
 
     @async_test
-    async def test_add_buggy_listener(self, loop, console, results):
-        class MyListener(BaseListener):
-            def on_response_received(self, **options):
-                raise Exception("Bam")
-
-        l = MyListener()
-        async with self._get_session(loop, console,
-                                     verbose=2) as session:
-            session.add_listener(l)
-            request = Request()
-            binary_body = b''
-            response = Response(body=binary_body)
-            await session.send_event('response_received',
-                                     response=response,
-                                     request=request)
-
-        resp = await serialize(console)
-        self.assertTrue("Bam" in resp)
-
-    @async_test
     async def test_add_listener(self, loop, console, results):
         class MyListener(BaseListener):
             def __init__(self):
@@ -46,7 +26,7 @@ class TestLoggedClientSession(TestLoop):
         l = MyListener()
         async with self._get_session(loop, console,
                                      verbose=2) as session:
-            session.add_listener(l)
+            session.eventer.add_listener(l)
             request = Request()
             binary_body = b''
             response = Response(body=binary_body)


### PR DESCRIPTION
This is a proof-of-concept of adding more events to Molotov mentioned in #84.

New events:
`scenario_success(scenario: dict, wid: int)` — fired every time single execution of scenario suceeds
`scenario_failure(scenario: dict, exception: Exception, wid: int)` — fired every time single execution of scenario fails
`current_workers(workers: int)` — fired once per second and contains a number of active workers

I also refactored event sending into separate class. There might be better designs than an `EventSender` class, but this one works pretty well.

Little TODO list to track progress:
- [x] code
- [x] refactor
- [x] test
- [x] document