### PR TITLE
Python 3.10 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ molotov
    :target: https://molotov.readthedocs.io
 
 
-Simple Python 3.6+ tool to write load tests.
+Simple Python 3.7+ tool to write load tests.
 
 Based on `asyncio <https://docs.python.org/3/library/asyncio.html>`_,
 Built with `aiohttp <http://aiohttp.readthedocs.io>`_ 3.x

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
 molotov
 =======
 
-Simple Python 3.6+ tool to write load tests.
+Simple Python 3.7+ tool to write load tests.
 
 Based on `asyncio <https://docs.python.org/3/library/asyncio.html>`_,
 `aiohttp.client <http://aiohttp.readthedocs.io/en/stable/client.html>`_.

--- a/molotov/runner.py
+++ b/molotov/runner.py
@@ -54,7 +54,7 @@ class Runner(object):
         return future.result()
 
     def gather(self, *futures):
-        return asyncio.gather(*futures, loop=self.loop, return_exceptions=True)
+        return asyncio.gather(*futures, return_exceptions=True)
 
     def ensure_future(self, coro):
         return asyncio.ensure_future(coro, loop=self.loop)

--- a/molotov/tests/statsd.py
+++ b/molotov/tests/statsd.py
@@ -51,7 +51,7 @@ class UDPServer(object):
             await self._stop
             ctx["proto"].disconnect()
 
-        await asyncio.gather(conn, listen_for_stop(), loop=self.loop)
+        await asyncio.gather(conn, listen_for_stop())
         self._done.set_result(True)
 
     def flush(self):

--- a/molotov/util.py
+++ b/molotov/util.py
@@ -194,7 +194,7 @@ def get_var(name, factory=None):
 # taken from https://stackoverflow.com/a/37211337
 def _make_sleep():
     async def sleep(delay, result=None, *, loop=None):
-        coro = asyncio.sleep(delay, result=result, loop=loop)
+        coro = asyncio.sleep(delay, result=result)
         task = asyncio.ensure_future(coro, loop=loop)
         sleep.tasks.add(task)
         try:

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 import sys
 from setuptools import setup, find_packages
 
-if sys.version_info < (3, 6):
-    raise ValueError("Requires Python 3.6 or superior")
+if sys.version_info < (3, 7):
+    raise ValueError("Requires Python 3.7 or superior")
 
 from molotov import __version__  # NOQA
 
@@ -20,10 +20,10 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 downloadcache = {toxworkdir}/cache/
-envlist = py39,py38,py37,py36,flake8,docs,pypy3
+envlist = py310,py39,py38,py37,flake8,docs,pypy3
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
@@ -11,13 +11,6 @@ commands =
        - coverage combine
        coverage report -m
        - coveralls
-
-[testenv:py36]
-passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
-deps = -rtox-requirements.txt
-       -rrequirements.txt
-commands =
-       pytest --random-order-bucket=global -sv molotov/tests
 
 [testenv:pypy3]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
@@ -32,7 +25,7 @@ deps =
     flake8
 
 [testenv:docs]
-basepython=python3.6
+basepython=python3.7
 deps =
     -rrequirements.txt
     sphinx


### PR DESCRIPTION
Python 3.10 dropped support for the loop parameter to `asyncio.sleep()` and `gather()`, the default loop is used instead. I haven't audited whether any of these code paths now need to use `set_default_loop()`, but tests pass, so... LGTM?

Support for using the default loop was only added in 3.7, so this drops support for Python 3.6.

https://bugs.python.org/issue42392

Fixes: #137